### PR TITLE
Use the desired layout for the build-tree artifacts

### DIFF
--- a/src/runtime/hexagon_remote/CMakeLists.txt
+++ b/src/runtime/hexagon_remote/CMakeLists.txt
@@ -24,6 +24,7 @@ set(common_cache_args
   "-DHALIDE_HEXAGON_REMOTE_IDL:PATH=${CMAKE_CURRENT_BINARY_DIR}"
   "-DHEXAGON_SDK_ROOT:PATH=${HEXAGON_SDK_ROOT}"
   "-DHEXAGON_TOOLS_ROOT:PATH=${HEXAGON_TOOLS_ROOT}"
+  "-DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>"
 )
 
 if (CMAKE_BUILD_TYPE)
@@ -36,12 +37,14 @@ ExternalProject_Add(
   CMAKE_CACHE_ARGS
     "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=${HEXAGON_TOOLCHAIN}"
     ${common_cache_args}
-  INSTALL_COMMAND ""
+  PREFIX hexagon
   DEPENDS halide_hexagon_remote_idl
   CONFIGURE_HANDLED_BY_BUILD ON
 )
 
-foreach (abi IN ITEMS armeabi-v7a arm64-v8a)
+set(arm_abis armeabi-v7a arm64-v8a)
+set(arm_bits 32 64)
+foreach (abi bits IN ZIP_LISTS arm_abis arm_bits)
   ExternalProject_Add(
     halide_hexagon_host-${abi}
     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/android"
@@ -50,7 +53,7 @@ foreach (abi IN ITEMS armeabi-v7a arm64-v8a)
       "-DANDROID_ABI:STRING=${abi}"
       "-DANDROID_PLATFORM:STRING=21"
       ${common_cache_args}
-    INSTALL_COMMAND ""
+    PREFIX arm-${bits}-android
     DEPENDS halide_hexagon_remote_idl
     CONFIGURE_HANDLED_BY_BUILD ON
   )

--- a/src/runtime/hexagon_remote/android/CMakeLists.txt
+++ b/src/runtime/hexagon_remote/android/CMakeLists.txt
@@ -30,3 +30,8 @@ target_include_directories(
   ${HEXAGON_SDK_ROOT}/incs/stddef
 )
 target_link_libraries(halide_hexagon_host PRIVATE fastrpc::cdsprpc log)
+
+install(
+  TARGETS halide_hexagon_host
+  DESTINATION bin
+)

--- a/src/runtime/hexagon_remote/qurt/CMakeLists.txt
+++ b/src/runtime/hexagon_remote/qurt/CMakeLists.txt
@@ -40,3 +40,8 @@ target_include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../..
   ${HALIDE_HEXAGON_REMOTE_IDL}
 )
+
+install(
+  TARGETS sim_qurt hexagon_sim_remote halide_hexagon_remote_skel
+  DESTINATION bin
+)


### PR DESCRIPTION
Alternative to #1

Pros:

* The bin/ directories are clean of other artifacts (no `build.ninja` files)
* The RPATHs are stripped correctly

Cons:

* Longer

@pranavb-ca